### PR TITLE
Implement backup code regeneration

### DIFF
--- a/backend/authentication/migrations/0004_userprofile_backup_codes.py
+++ b/backend/authentication/migrations/0004_userprofile_backup_codes.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('authentication', '0003_notificationpreferences'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='backup_codes',
+            field=models.JSONField(default=list, blank=True),
+        ),
+    ]

--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -11,6 +11,7 @@ class UserProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
     phone_number = models.CharField(max_length=15, blank=True, null=True)
     two_fa_enabled = models.BooleanField(default=False)
+    backup_codes = models.JSONField(default=list, blank=True)
     role = models.CharField(max_length=10, choices=USER_ROLES, default='patient')
     
     def __str__(self):

--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -7,4 +7,9 @@ router.register(r'users', views.UserViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path(
+        'users/regenerate_backup_codes/',
+        views.UserViewSet.as_view({'post': 'regenerate_backup_codes'}),
+        name='user-regenerate-backup-codes',
+    ),
 ]

--- a/frontend/src/services/auth.service.js
+++ b/frontend/src/services/auth.service.js
@@ -33,6 +33,10 @@ export default {
     return api.get("auth/users/get_2fa_status/");
   },
 
+  regenerateBackupCodes() {
+    return api.post("auth/users/regenerate_backup_codes/");
+  },
+
   logout() {
     localStorage.removeItem("token");
     localStorage.removeItem("user");

--- a/frontend/src/views/TwoFactorAuth.vue
+++ b/frontend/src/views/TwoFactorAuth.vue
@@ -238,6 +238,15 @@
                 <i class="bi bi-check-circle"></i>
                 {{ successMessage }}
               </div>
+
+              <div v-if="backupCodes.length" class="alert alert-secondary mt-3">
+                <h5 class="mb-2">New Backup Codes</h5>
+                <ul class="list-unstyled mb-0">
+                  <li v-for="code in backupCodes" :key="code">
+                    <code>{{ code }}</code>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
@@ -267,6 +276,7 @@ export default {
     const verificationError = ref("");
     const error = ref("");
     const successMessage = ref("");
+    const backupCodes = ref([]);
 
     // Incarca statusul 2FA al utilizatorului
     const loadStatus = async () => {
@@ -399,7 +409,7 @@ export default {
       }
     };
 
-    // Regenereaza codurile de backup (placeholder pentru implementare viitoare)
+    // Regenereaza codurile de backup
     const regenerate2FA = async () => {
       if (
         !confirm(
@@ -413,9 +423,8 @@ export default {
       error.value = "";
 
       try {
-        // TODO: Implementare generare backup codes
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-
+        const response = await AuthService.regenerateBackupCodes();
+        backupCodes.value = response.data.backup_codes || [];
         successMessage.value = "Backup codes have been regenerated.";
 
         setTimeout(() => {
@@ -447,6 +456,7 @@ export default {
       verificationError,
       error,
       successMessage,
+      backupCodes,
       enable2FA,
       disable2FA,
       regenerate2FA,


### PR DESCRIPTION
## Summary
- add `backup_codes` field for users
- create action to regenerate backup codes
- route the new API endpoint
- expose endpoint on frontend auth service
- regenerate backup codes from TwoFactorAuth view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684868c5a4a4832e8afb5087633a4255