### PR TITLE
Use timezone aware datetimes

### DIFF
--- a/backend/appointments/serializers.py
+++ b/backend/appointments/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from datetime import date, datetime, time
+from django.utils import timezone
 from .models import Appointment
 from doctors.serializers import DoctorSerializer, ScheduleSerializer
 from patients.serializers import PatientSerializer
@@ -24,8 +25,11 @@ class AppointmentSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("This time slot is no longer available.")
         
         # 2. Verifica daca programarea nu este in trecut
-        appointment_datetime = datetime.combine(value.date, value.start_time)
-        now = datetime.now()
+        appointment_datetime = timezone.make_aware(
+            datetime.combine(value.date, value.start_time),
+            timezone.get_current_timezone()
+        )
+        now = timezone.now()
         
         if appointment_datetime <= now:
             raise serializers.ValidationError("Cannot book appointments in the past.")

--- a/backend/appointments/tests.py
+++ b/backend/appointments/tests.py
@@ -1,3 +1,44 @@
 from django.test import TestCase
+from django.utils import timezone
+from django.conf import settings
+from datetime import time, timedelta
+from django.contrib.auth.models import User
+from doctors.models import Doctor, Schedule
+from patients.models import Patient
+from .serializers import AppointmentSerializer
 
-# Create your tests here.
+
+class AppointmentTimeZoneTest(TestCase):
+    def setUp(self):
+        doctor_user = User.objects.create_user(username='doc', password='pass')
+        self.doctor = Doctor.objects.create(user=doctor_user, speciality='gen')
+
+        patient_user = User.objects.create_user(username='pat', password='pass')
+        self.patient = Patient.objects.create(user=patient_user)
+
+    def test_created_at_uses_project_timezone(self):
+        tz = timezone.get_current_timezone()
+        self.assertEqual(str(tz), settings.TIME_ZONE)
+
+        schedule = Schedule.objects.create(
+            doctor=self.doctor,
+            date=timezone.localdate() + timedelta(days=1),
+            start_time=time(10, 0),
+            end_time=time(11, 0),
+            is_available=True,
+        )
+
+        serializer = AppointmentSerializer(data={
+            'patient': self.patient.id,
+            'doctor': self.doctor.id,
+            'schedule': schedule.id,
+        })
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        appointment = serializer.save()
+
+        self.assertEqual(
+            timezone.localtime(appointment.created_at).tzinfo,
+            tz,
+        )
+

--- a/backend/setup_test_data.py
+++ b/backend/setup_test_data.py
@@ -13,6 +13,7 @@ from doctors.models import Doctor, Schedule
 from patients.models import Patient
 from appointments.models import Appointment
 from datetime import datetime, timedelta
+from django.utils import timezone
 
 def setup_test_data():
     """Creeaza datele necesare pentru test"""
@@ -42,7 +43,7 @@ def setup_test_data():
     )
     
     # 2. Creeaza un schedule slot pentru test
-    tomorrow = datetime.now().date() + timedelta(days=1)
+    tomorrow = timezone.now().date() + timedelta(days=1)
     schedule, created = Schedule.objects.get_or_create(
         doctor=doctor,
         date=tomorrow,


### PR DESCRIPTION
- use `timezone.now()` in appointments serializer and make comparisons timezone aware
- update test data setup to use timezone aware dates
- add test that verifies the project's timezone is applied when creating appointments