### PR TITLE
Add basic backend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ The backend uses the following environment variables:
 - `SECRET_KEY` – the Django secret key used for cryptographic signing. **Required**.
 
 Create a `.env` file in the `backend` directory and define these variables before running the app.
+
+## Running Tests
+
+1. Install the Python requirements from `backend/requirements.txt`.
+2. Ensure `SECRET_KEY` is set in `backend/.env` or exported as an environment variable.
+3. Execute the tests from the `backend` directory with `python manage.py test`.
+4. Tests run using a separate SQLite database located at `backend/test_db.sqlite3` which can be safely removed after the tests finish.

--- a/backend/appointments/tests.py
+++ b/backend/appointments/tests.py
@@ -1,4 +1,6 @@
 from django.test import TestCase
+from rest_framework.test import APIClient
+from django.urls import reverse
 from django.utils import timezone
 from django.conf import settings
 from datetime import time, timedelta
@@ -41,4 +43,38 @@ class AppointmentTimeZoneTest(TestCase):
             timezone.localtime(appointment.created_at).tzinfo,
             tz,
         )
+
+
+class AppointmentBookingTest(TestCase):
+    def setUp(self):
+        doctor_user = User.objects.create_user(username='doc2', password='pass')
+        self.doctor = Doctor.objects.create(user=doctor_user, speciality='gen')
+
+        patient_user = User.objects.create_user(username='pat2', password='pass')
+        self.patient_user = patient_user
+        self.patient = Patient.objects.create(user=patient_user)
+
+        self.schedule = Schedule.objects.create(
+            doctor=self.doctor,
+            date=timezone.localdate() + timedelta(days=1),
+            start_time=time(12, 0),
+            end_time=time(13, 0),
+            is_available=True,
+        )
+
+    def test_booking_marks_schedule_unavailable(self):
+        client = APIClient()
+        client.force_authenticate(user=self.patient_user)
+        url = reverse('appointment-list')
+        data = {
+            'patient': self.patient.id,
+            'doctor': self.doctor.id,
+            'schedule': self.schedule.id,
+        }
+
+        response = client.post(url, data, format='json')
+        self.assertEqual(response.status_code, 201)
+
+        self.schedule.refresh_from_db()
+        self.assertFalse(self.schedule.is_available)
 

--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -1,3 +1,37 @@
-from django.test import TestCase
+from rest_framework.test import APITestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from patients.models import Patient
+from doctors.models import Doctor
 
-# Create your tests here.
+
+class UserRegistrationTest(APITestCase):
+    def test_patient_registration_creates_related_models(self):
+        url = reverse('user-register')
+        data = {
+            'username': 'newpatient',
+            'password': 'pass1234',
+            'email': 'patient@example.com',
+            'user_type': 'patient'
+        }
+
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, 201)
+
+        self.assertTrue(User.objects.filter(username='newpatient').exists())
+        self.assertTrue(Patient.objects.filter(user__username='newpatient').exists())
+
+    def test_doctor_registration_creates_related_models(self):
+        url = reverse('user-register')
+        data = {
+            'username': 'docuser',
+            'password': 'pass1234',
+            'email': 'doc@example.com',
+            'user_type': 'doctor'
+        }
+
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, 201)
+
+        self.assertTrue(User.objects.filter(username='docuser').exists())
+        self.assertTrue(Doctor.objects.filter(user__username='docuser').exists())

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -122,6 +122,11 @@ DATABASES = {
     }
 }
 
+# Use a separate database when running tests
+import sys
+if 'test' in sys.argv:
+    DATABASES['default']['NAME'] = BASE_DIR / 'test_db.sqlite3'
+
 
 # Password validation
 # https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators

--- a/backend/doctors/tests.py
+++ b/backend/doctors/tests.py
@@ -1,3 +1,28 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+from datetime import date, time, timedelta
+from django.db.utils import IntegrityError
+from .models import Doctor, Schedule
 
-# Create your tests here.
+
+class ScheduleModelTest(TestCase):
+    def setUp(self):
+        user = User.objects.create_user(username='doc', password='pass')
+        self.doctor = Doctor.objects.create(user=user, speciality='gen')
+
+    def test_schedule_unique_constraint(self):
+        day = date.today() + timedelta(days=1)
+        Schedule.objects.create(
+            doctor=self.doctor,
+            date=day,
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+
+        with self.assertRaises(IntegrityError):
+            Schedule.objects.create(
+                doctor=self.doctor,
+                date=day,
+                start_time=time(9, 0),
+                end_time=time(10, 0),
+            )

--- a/backend/notifications/tests.py
+++ b/backend/notifications/tests.py
@@ -1,3 +1,15 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+from .models import Notification
 
-# Create your tests here.
+
+class NotificationModelTest(TestCase):
+    def test_str_representation(self):
+        user = User.objects.create_user(username='u', password='p')
+        notification = Notification.objects.create(
+            user=user,
+            type='system',
+            title='Hello',
+            message='World'
+        )
+        self.assertEqual(str(notification), 'Hello to u')

--- a/backend/patients/tests.py
+++ b/backend/patients/tests.py
@@ -1,3 +1,12 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+from .models import Patient
 
-# Create your tests here.
+
+class PatientModelTest(TestCase):
+    def test_str_representation(self):
+        user = User.objects.create_user(
+            username='pat', password='pass', first_name='John', last_name='Doe'
+        )
+        patient = Patient.objects.create(user=user)
+        self.assertEqual(str(patient), 'Patient: John Doe')


### PR DESCRIPTION
## Summary
- add basic registration and booking tests
- create simple model tests for each app
- isolate tests with a dedicated SQLite database
- document how to run the tests

## Testing
- `python manage.py test` *(fails: Could not install Django)*

------
https://chatgpt.com/codex/tasks/task_e_684872510ed8832e894d344265755b41