### PR TITLE
Limit access to doctor schedules and patient records

### DIFF
--- a/backend/doctors/tests.py
+++ b/backend/doctors/tests.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 from datetime import date, time, timedelta
 from django.db.utils import IntegrityError
+from django.urls import reverse
+from rest_framework.test import APIClient
 from .models import Doctor, Schedule
 
 
@@ -26,3 +28,42 @@ class ScheduleModelTest(TestCase):
                 start_time=time(9, 0),
                 end_time=time(10, 0),
             )
+
+
+class ScheduleViewsetQuerysetTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        user1 = User.objects.create_user(username='d1', password='pass')
+        user2 = User.objects.create_user(username='d2', password='pass')
+
+        self.doctor1 = Doctor.objects.create(user=user1, speciality='gen')
+        self.doctor2 = Doctor.objects.create(user=user2, speciality='gen')
+
+        Schedule.objects.create(
+            doctor=self.doctor1,
+            date=date.today() + timedelta(days=1),
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+        Schedule.objects.create(
+            doctor=self.doctor2,
+            date=date.today() + timedelta(days=1),
+            start_time=time(11, 0),
+            end_time=time(12, 0),
+        )
+
+    def test_doctor_sees_only_their_schedules(self):
+        self.client.force_authenticate(user=self.doctor1.user)
+        url = reverse('schedule-list')
+        response = self.client.get(url)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['doctor'], self.doctor1.id)
+
+    def test_staff_sees_all_schedules(self):
+        staff = User.objects.create_user(username='staff', password='pass', is_staff=True)
+        self.client.force_authenticate(user=staff)
+        url = reverse('schedule-list')
+        response = self.client.get(url)
+        self.assertEqual(len(response.data), 2)
+

--- a/backend/doctors/views.py
+++ b/backend/doctors/views.py
@@ -15,6 +15,14 @@ class DoctorViewSet(viewsets.ModelViewSet):
     serializer_class = DoctorSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_staff or user.is_superuser:
+            return Doctor.objects.all()
+        if hasattr(user, "doctor"):
+            return Doctor.objects.filter(pk=user.doctor.pk)
+        return Doctor.objects.none()
+
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
@@ -26,6 +34,14 @@ class ScheduleViewSet(viewsets.ModelViewSet):
     queryset = Schedule.objects.all()
     serializer_class = ScheduleSerializer
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_staff or user.is_superuser:
+            return Schedule.objects.all()
+        if hasattr(user, "doctor"):
+            return Schedule.objects.filter(doctor=user.doctor)
+        return Schedule.objects.none()
     
     # @method_decorator(cache_page(60*5))  # Cache pentru 5 minute, dezactivat momentan
     def list(self, request, *args, **kwargs):

--- a/backend/patients/tests.py
+++ b/backend/patients/tests.py
@@ -1,6 +1,11 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.test import APIClient
+from doctors.models import Doctor, Schedule
+from appointments.models import Appointment
 from .models import Patient
+from datetime import date, time, timedelta
 
 
 class PatientModelTest(TestCase):
@@ -10,3 +15,59 @@ class PatientModelTest(TestCase):
         )
         patient = Patient.objects.create(user=user)
         self.assertEqual(str(patient), 'Patient: John Doe')
+
+
+class PatientViewsetQuerysetTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        doctor_user = User.objects.create_user(username='doc', password='pass')
+        other_doc_user = User.objects.create_user(username='doc2', password='pass')
+
+        self.doctor = Doctor.objects.create(user=doctor_user, speciality='gen')
+        self.other_doctor = Doctor.objects.create(user=other_doc_user, speciality='gen')
+
+        patient1_user = User.objects.create_user(username='p1', password='pass')
+        patient2_user = User.objects.create_user(username='p2', password='pass')
+
+        self.patient1 = Patient.objects.create(user=patient1_user)
+        self.patient2 = Patient.objects.create(user=patient2_user)
+
+        schedule1 = Schedule.objects.create(
+            doctor=self.doctor,
+            date=date.today() + timedelta(days=1),
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+
+        schedule2 = Schedule.objects.create(
+            doctor=self.other_doctor,
+            date=date.today() + timedelta(days=1),
+            start_time=time(11, 0),
+            end_time=time(12, 0),
+        )
+
+        Appointment.objects.create(patient=self.patient1, doctor=self.doctor, schedule=schedule1)
+        Appointment.objects.create(patient=self.patient2, doctor=self.other_doctor, schedule=schedule2)
+
+    def test_doctor_sees_only_his_patients(self):
+        self.client.force_authenticate(user=self.doctor.user)
+        url = reverse('patient-list')
+        response = self.client.get(url)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], self.patient1.id)
+
+    def test_patient_sees_only_self(self):
+        self.client.force_authenticate(user=self.patient1.user)
+        url = reverse('patient-list')
+        response = self.client.get(url)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], self.patient1.id)
+
+    def test_staff_sees_all_patients(self):
+        staff = User.objects.create_user(username='staff', password='pass', is_staff=True)
+        self.client.force_authenticate(user=staff)
+        url = reverse('patient-list')
+        response = self.client.get(url)
+        self.assertEqual(len(response.data), 2)
+

--- a/backend/patients/views.py
+++ b/backend/patients/views.py
@@ -6,3 +6,13 @@ class PatientViewSet(viewsets.ModelViewSet):
     queryset = Patient.objects.all()
     serializer_class = PatientSerializer
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_staff or user.is_superuser:
+            return Patient.objects.all()
+        if hasattr(user, "doctor"):
+            return Patient.objects.filter(appointments__doctor=user.doctor).distinct()
+        if hasattr(user, "patient"):
+            return Patient.objects.filter(pk=user.patient.pk)
+        return Patient.objects.none()


### PR DESCRIPTION
- restrict doctors and schedules API access based on user role
- doctors can only view their own schedules
- doctors see only their own patients
- patients are limited to their record
- staff users retain full access
- add unit tests for the new queryset logic