### PR TITLE
Replace localStorage with Vuex state

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -9,7 +9,7 @@ import AppointmentDetails from "../views/AppointmentDetails.vue";
 import Profile from "../views/Profile.vue";
 import AppointmentConfirmation from "../views/AppointmentConfirmation.vue";
 import TwoFactorAuth from "../views/TwoFactorAuth.vue";
-import AuthService from "@/services/auth.service";
+import store from "@/store";
 
 const routes = [
   {
@@ -33,7 +33,7 @@ const routes = [
     path: "/dashboard",
     name: "Dashboard",
     beforeEnter: (to, from, next) => {
-      const user = AuthService.getUser();
+      const user = store.getters["auth/currentUser"];
       if (user && user.role === "doctor") {
         next({ name: "DoctorDashboard" });
       } else if (user && user.role === "patient") {
@@ -107,7 +107,7 @@ const router = createRouter({
 
 // Navigatie guard pentru a verifica autentificarea si rolurile
 router.beforeEach((to, from, next) => {
-  const isAuthenticated = AuthService.isLoggedIn();
+  const isAuthenticated = store.getters["auth/isAuthenticated"];
 
   // Verifica daca ruta necesita autentificare
   if (to.matched.some((record) => record.meta.requiresAuth)) {
@@ -115,7 +115,7 @@ router.beforeEach((to, from, next) => {
       next({ name: "Login" });
     } else {
       // Verifica rolul utilizatorului daca este specificat in meta
-      const user = AuthService.getUser();
+      const user = store.getters["auth/currentUser"];
       if (to.meta.role && user.role !== to.meta.role) {
         next({ name: "Dashboard" }); // Redirectioneaza la dashboard-ul potrivit
       } else {

--- a/frontend/src/services/auth.service.js
+++ b/frontend/src/services/auth.service.js
@@ -38,21 +38,6 @@ export default {
   },
 
   logout() {
-    return api.post("auth/users/logout/").finally(() => {
-      localStorage.removeItem("user");
-    });
-  },
-
-  saveUserData(userData) {
-    localStorage.setItem("user", JSON.stringify(userData));
-  },
-
-  getUser() {
-    const user = localStorage.getItem("user");
-    return user ? JSON.parse(user) : null;
-  },
-
-  isLoggedIn() {
-    return !!this.getUser();
+    return api.post("auth/users/logout/");
   },
 };

--- a/frontend/src/store/modules/auth.js
+++ b/frontend/src/store/modules/auth.js
@@ -4,7 +4,7 @@ export default {
   namespaced: true,
 
   state: {
-    user: AuthService.getUser(),
+    user: null,
     token: null,
     requires2FA: false,
     tempUserId: null,
@@ -51,7 +51,6 @@ export default {
             patient_id: response.data.patient_id,
           };
 
-          AuthService.saveUserData(userData);
           commit("setUser", userData);
           return { success: true };
         }
@@ -73,7 +72,6 @@ export default {
           patient_id: response.data.patient_id,
         };
 
-        AuthService.saveUserData(userData);
         commit("setUser", userData);
         commit("setRequires2FA", { requires2FA: false, userId: null });
         return { success: true };

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -699,7 +699,7 @@ export default {
         is2FAEnabled.value = response.data.two_fa_enabled;
       } catch (error) {
         console.error("Failed to load 2FA status", error);
-        // Fallback to localStorage data
+        // Fallback to stored user data
         is2FAEnabled.value = currentUser.value?.two_fa_enabled || false;
       } finally {
         loading2FAStatus.value = false;
@@ -765,8 +765,7 @@ export default {
         };
         store.commit("auth/setUser", updatedUser);
 
-        // Update localStorage
-        AuthService.saveUserData(updatedUser);
+
 
         personalInfoSaved.value = true;
 

--- a/frontend/src/views/TwoFactorAuth.vue
+++ b/frontend/src/views/TwoFactorAuth.vue
@@ -257,12 +257,14 @@
 
 <script>
 import { ref, onMounted } from "vue";
+import { useStore } from "vuex";
 import AuthService from "@/services/auth.service";
 
 export default {
   name: "TwoFactorAuth",
 
   setup() {
+    const store = useStore();
     const loading = ref(true);
     const is2FAEnabled = ref(false);
     const showSetup = ref(false);
@@ -329,11 +331,9 @@ export default {
         is2FAEnabled.value = true;
         showSetup.value = false;
 
-        // Actualizeaza profilul utilizatorului în localStorage
-        const user = AuthService.getUser();
+        const user = store.getters["auth/currentUser"];
         if (user) {
-          user.two_fa_enabled = true;
-          localStorage.setItem("user", JSON.stringify(user));
+          store.commit("auth/setUser", { ...user, two_fa_enabled: true });
         }
 
         successMessage.value =
@@ -386,11 +386,9 @@ export default {
         // Actualizeaza starea locala
         is2FAEnabled.value = false;
 
-        // Actualizeaza profilul utilizatorului in localStorage
-        const user = AuthService.getUser();
+        const user = store.getters["auth/currentUser"];
         if (user) {
-          user.two_fa_enabled = false;
-          localStorage.setItem("user", JSON.stringify(user));
+          store.commit("auth/setUser", { ...user, two_fa_enabled: false });
         }
 
         successMessage.value = "Two-factor authentication has been disabled.";


### PR DESCRIPTION
## Summary
- remove localStorage helpers from `auth.service.js`
- store authentication info only in Vuex state
- update router and 2FA/profile components to read from the store

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487beb1fc8832e99de88c27c2db09f