### PR TITLE
Add backup code authentication endpoint

### DIFF
--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.contrib.auth.hashers import check_password
 
 class UserProfile(models.Model):
     USER_ROLES = (
@@ -13,9 +14,25 @@ class UserProfile(models.Model):
     two_fa_enabled = models.BooleanField(default=False)
     backup_codes = models.JSONField(default=list, blank=True)
     role = models.CharField(max_length=10, choices=USER_ROLES, default='patient')
-    
+
     def __str__(self):
         return f"{self.user.username}'s profile - {self.role}"
+
+    def verify_backup_code(self, code: str) -> bool:
+        """Validate a backup code and invalidate it if used.
+
+        Args:
+            code (str): The plaintext backup code supplied by the user.
+
+        Returns:
+            bool: True if the code is valid and has been invalidated, False otherwise.
+        """
+        for hashed_code in list(self.backup_codes):
+            if check_password(code, hashed_code):
+                self.backup_codes.remove(hashed_code)
+                self.save(update_fields=["backup_codes"])
+                return True
+        return False
 
 class NotificationPreferences(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='notification_preferences')


### PR DESCRIPTION
## Summary
- add `UserProfile.verify_backup_code` to check and consume hashed codes
- support backup-code login with new `verify_backup_code` action and auth token issuance
- test backup code login and token issuance

## Testing
- `DEBUG=1 SECRET_KEY=test python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689460dca050832eb194767c838b90d7