### PR TITLE
refactor: reuse shared date/time formatters in booking view

### DIFF
--- a/frontend/src/views/BookAppointment.vue
+++ b/frontend/src/views/BookAppointment.vue
@@ -199,6 +199,7 @@ import DoctorService from "@/services/doctor.service";
 import AppointmentService from "@/services/appointment.service";
 import DoctorCalendar from "@/components/calendar/DoctorCalendar.vue";
 import { useStore } from "vuex";
+import { formatDate, formatTime } from "@/utils/formatters";
 
 export default {
   name: "BookAppointment",
@@ -288,21 +289,6 @@ export default {
       } finally {
         booking.value = false;
       }
-    };
-
-    const formatDate = (dateString) => {
-      return new Date(dateString).toLocaleDateString("ro-RO", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      });
-    };
-
-    const formatTime = (timeString) => {
-      return new Date(`1970-01-01T${timeString}:00`).toLocaleTimeString(
-        "ro-RO",
-        { hour: "2-digit", minute: "2-digit" }
-      );
     };
 
     onMounted(loadDoctors);


### PR DESCRIPTION
## Summary
- use `formatDate` and `formatTime` from shared formatters utility in BookAppointment view
- clean up redundant local date and time formatter functions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `python -m pytest` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895de4e4848832ebb6c023e3251235c