### PR TITLE
Check active status on login

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -54,10 +54,13 @@ class UserViewSet(viewsets.ModelViewSet):
         password = request.data.get('password')
         
         user = authenticate(username=username, password=password)
-        
+
         if user is not None:
+            if not user.is_active:
+                return Response({'error': 'Account is inactive'}, status=status.HTTP_403_FORBIDDEN)
+
             profile = UserProfile.objects.get(user=user)
-            
+
             if profile.two_fa_enabled:
                 return Response({
                     'message': '2FA required',

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -140,6 +140,8 @@ if 'test' in sys.argv:
     DATABASES['default']['NAME'] = BASE_DIR / 'test_db.sqlite3'
     # For tests, use more aggressive settings
     DATABASES['default']['OPTIONS']['timeout'] = 60
+    # Disable HTTPS redirect during tests to avoid 301 responses
+    SECURE_SSL_REDIRECT = False
 
 
 # Password validation


### PR DESCRIPTION
- block inactive users from obtaining auth tokens during login
- disable HTTPS redirect in test environment to prevent spurious redirects