### PR TITLE
Add expiring tokens with rotation on login

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -68,7 +68,8 @@ class UserViewSet(viewsets.ModelViewSet):
                     'requires_2fa': True
                 }, status=status.HTTP_200_OK)
             
-            token, _ = Token.objects.get_or_create(user=user)
+            Token.objects.filter(user=user).delete()
+            token = Token.objects.create(user=user)
 
             # Get additional IDs based on role
             doctor_id = None
@@ -282,7 +283,8 @@ class UserViewSet(viewsets.ModelViewSet):
                 logger = logging.getLogger(__name__)
                 logger.info(f"Successful 2FA login for user {user.username} from IP {request.META.get('REMOTE_ADDR')}")
                 
-                token, _ = Token.objects.get_or_create(user=user)
+                Token.objects.filter(user=user).delete()
+                token = Token.objects.create(user=user)
                 profile = UserProfile.objects.get(user=user)
                 
                 doctor_id = None
@@ -364,7 +366,8 @@ class UserViewSet(viewsets.ModelViewSet):
         if not profile.verify_backup_code(code):
             return Response({'error': 'Invalid backup code'}, status=status.HTTP_401_UNAUTHORIZED)
 
-        token, _ = Token.objects.get_or_create(user=user)
+        Token.objects.filter(user=user).delete()
+        token = Token.objects.create(user=user)
 
         doctor_id = None
         patient_id = None

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -226,12 +226,16 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',
         'authentication.authentication.CookieTokenAuthentication',
-        'rest_framework.authentication.TokenAuthentication',
+        'authentication.authentication.ExpiringTokenAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],
 }
+
+# Lifetime for authentication tokens
+from datetime import timedelta
+TOKEN_EXPIRATION_TIME = timedelta(hours=1)
 
 # Email Configuration
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/backend/doctors/tests.py
+++ b/backend/doctors/tests.py
@@ -7,13 +7,20 @@ from rest_framework.test import APIClient
 from .models import Doctor, Schedule
 
 
+def next_weekday(d: date) -> date:
+    """Return the next weekday (Monday-Friday) on or after ``d``."""
+    while d.weekday() >= 5:  # 5 = Saturday, 6 = Sunday
+        d += timedelta(days=1)
+    return d
+
+
 class ScheduleModelTest(TestCase):
     def setUp(self):
         user = User.objects.create_user(username='doc', password='pass')
         self.doctor = Doctor.objects.create(user=user, speciality='gen')
 
     def test_schedule_unique_constraint(self):
-        day = date.today() + timedelta(days=1)
+        day = next_weekday(date.today() + timedelta(days=1))
         Schedule.objects.create(
             doctor=self.doctor,
             date=day,
@@ -40,15 +47,16 @@ class ScheduleViewsetQuerysetTest(TestCase):
         self.doctor1 = Doctor.objects.create(user=user1, speciality='gen')
         self.doctor2 = Doctor.objects.create(user=user2, speciality='gen')
 
+        schedule_day = next_weekday(date.today() + timedelta(days=1))
         Schedule.objects.create(
             doctor=self.doctor1,
-            date=date.today() + timedelta(days=1),
+            date=schedule_day,
             start_time=time(9, 0),
             end_time=time(10, 0),
         )
         Schedule.objects.create(
             doctor=self.doctor2,
-            date=date.today() + timedelta(days=1),
+            date=schedule_day,
             start_time=time(11, 0),
             end_time=time(12, 0),
         )
@@ -84,7 +92,7 @@ class ScheduleViewsetCreateTest(TestCase):
         self.client.force_authenticate(user=self.doctor1.user)
         data = {
             'doctor': self.doctor2.id,
-            'date': date.today() + timedelta(days=1),
+            'date': next_weekday(date.today() + timedelta(days=1)),
             'start_time': time(9, 0),
             'end_time': time(10, 0),
             'is_available': True,
@@ -102,7 +110,7 @@ class ScheduleViewsetCreateTest(TestCase):
         self.client.force_authenticate(user=user)
         data = {
             'doctor': self.doctor1.id,
-            'date': date.today() + timedelta(days=1),
+            'date': next_weekday(date.today() + timedelta(days=1)),
             'start_time': time(9, 0),
             'end_time': time(10, 0),
             'is_available': True,

--- a/backend/patients/tests.py
+++ b/backend/patients/tests.py
@@ -8,6 +8,13 @@ from .models import Patient
 from datetime import date, time, timedelta
 
 
+def next_weekday(d: date) -> date:
+    """Return the next weekday (Monday-Friday) on or after ``d``."""
+    while d.weekday() >= 5:
+        d += timedelta(days=1)
+    return d
+
+
 class PatientModelTest(TestCase):
     def test_str_representation(self):
         user = User.objects.create_user(
@@ -33,16 +40,17 @@ class PatientViewsetQuerysetTest(TestCase):
         self.patient1 = Patient.objects.create(user=patient1_user)
         self.patient2 = Patient.objects.create(user=patient2_user)
 
+        schedule_day = next_weekday(date.today() + timedelta(days=1))
         schedule1 = Schedule.objects.create(
             doctor=self.doctor,
-            date=date.today() + timedelta(days=1),
+            date=schedule_day,
             start_time=time(9, 0),
             end_time=time(10, 0),
         )
 
         schedule2 = Schedule.objects.create(
             doctor=self.other_doctor,
-            date=date.today() + timedelta(days=1),
+            date=schedule_day,
             start_time=time(11, 0),
             end_time=time(12, 0),
         )


### PR DESCRIPTION
- add ExpiringTokenAuthentication to enforce token expiration and support cookie-based auth
- rotate tokens on each login and 2FA/backup code verification
- set token lifetime in settings and apply new authentication class
- ensure schedule-related tests use the next available weekday to avoid weekend failures