### PR TITLE
Adopt bearer token auth with refresh cookie

### DIFF
--- a/backend/authentication/authentication.py
+++ b/backend/authentication/authentication.py
@@ -9,6 +9,8 @@ from rest_framework.authentication import TokenAuthentication
 class ExpiringTokenAuthentication(TokenAuthentication):
     """Token authentication that verifies token expiry."""
 
+    keyword = "Bearer"
+
     def authenticate_credentials(self, key):
         model = self.get_model()
         try:
@@ -25,13 +27,3 @@ class ExpiringTokenAuthentication(TokenAuthentication):
             raise exceptions.AuthenticationFailed("Token has expired.")
 
         return (token.user, token)
-
-
-class CookieTokenAuthentication(ExpiringTokenAuthentication):
-    """Token authentication using the 'auth_token' cookie."""
-
-    def authenticate(self, request):
-        token = request.COOKIES.get("auth_token")
-        if not token:
-            return None
-        return self.authenticate_credentials(token)

--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -49,7 +49,7 @@ class ChangePasswordTest(APITestCase):
         )
         self.client.force_authenticate(user=self.user)
 
-    def test_change_password_sets_auth_cookie(self):
+    def test_change_password_sets_refresh_cookie(self):
         url = reverse('user-change-password')
 
         response = self.client.post(
@@ -63,9 +63,9 @@ class ChangePasswordTest(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('token', response.data)
-        self.assertIn('auth_token', response.cookies)
+        self.assertIn('refresh_token', response.cookies)
 
-        cookie_token = response.cookies['auth_token'].value
+        cookie_token = response.cookies['refresh_token'].value
         self.assertTrue(Token.objects.filter(key=cookie_token, user=self.user).exists())
 
 
@@ -90,10 +90,10 @@ class BackupCodeAuthTest(APITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('auth_token', response.cookies)
+        self.assertIn('refresh_token', response.cookies)
 
         # Token should exist and backup code should be consumed
-        token_key = response.cookies['auth_token'].value
+        token_key = response.cookies['refresh_token'].value
         self.assertTrue(Token.objects.filter(key=token_key, user=self.user).exists())
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.backup_codes, [])

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -79,7 +79,7 @@ class UserViewSet(viewsets.ModelViewSet):
                 doctor_id = user.doctor.id
             elif profile.role == 'patient' and hasattr(user, 'patient'):
                 patient_id = user.patient.id
-            
+
             response = Response({
                 'user_id': user.id,
                 'email': user.email,
@@ -89,15 +89,16 @@ class UserViewSet(viewsets.ModelViewSet):
                 'last_name': user.last_name,
                 'doctor_id': doctor_id,
                 'patient_id': patient_id,
-                'two_fa_enabled': profile.two_fa_enabled
+                'two_fa_enabled': profile.two_fa_enabled,
+                'token': token.key,
             }, status=status.HTTP_200_OK)
             secure = not getattr(settings, 'DEBUG', False)
             response.set_cookie(
-                'auth_token',
+                'refresh_token',
                 token.key,
                 httponly=True,
                 secure=secure,
-                samesite='Lax'
+                samesite='Strict'
             )
             return response
         else:
@@ -107,7 +108,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def logout(self, request):
         Token.objects.filter(user=request.user).delete()
         response = Response({'message': 'Logged out'}, status=status.HTTP_200_OK)
-        response.delete_cookie('auth_token')
+        response.delete_cookie('refresh_token')
         return response
     
     @action(detail=False, methods=['post'], permission_classes=[permissions.IsAuthenticated])
@@ -303,15 +304,16 @@ class UserViewSet(viewsets.ModelViewSet):
                     'last_name': user.last_name,
                     'doctor_id': doctor_id,
                     'patient_id': patient_id,
-                    'two_fa_enabled': profile.two_fa_enabled
+                    'two_fa_enabled': profile.two_fa_enabled,
+                    'token': token.key,
                 }, status=status.HTTP_200_OK)
                 secure = not getattr(settings, 'DEBUG', False)
                 response.set_cookie(
-                    'auth_token',
+                    'refresh_token',
                     token.key,
                     httponly=True,
                     secure=secure,
-                    samesite='Lax'
+                    samesite='Strict'
                 )
                 return response
             else:
@@ -387,16 +389,17 @@ class UserViewSet(viewsets.ModelViewSet):
                 'doctor_id': doctor_id,
                 'patient_id': patient_id,
                 'two_fa_enabled': profile.two_fa_enabled,
+                'token': token.key,
             },
             status=status.HTTP_200_OK,
         )
         secure = not getattr(settings, 'DEBUG', False)
         response.set_cookie(
-            'auth_token',
+            'refresh_token',
             token.key,
             httponly=True,
             secure=secure,
-            samesite='Lax',
+            samesite='Strict',
         )
         return response
     
@@ -541,11 +544,11 @@ class UserViewSet(viewsets.ModelViewSet):
 
         secure = not getattr(settings, 'DEBUG', False)
         response.set_cookie(
-            'auth_token',
+            'refresh_token',
             new_token.key,
             httponly=True,
             secure=secure,
-            samesite='Lax',
+            samesite='Strict',
         )
 
         return response

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -218,14 +218,12 @@ CORS_ALLOWED_HEADERS = [
     'dnt',
     'origin',
     'user-agent',
-    'x-csrftoken',
     'x-requested-with',
 ]
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',
-        'authentication.authentication.CookieTokenAuthentication',
         'authentication.authentication.ExpiringTokenAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [

--- a/backend/test_email_simple.py
+++ b/backend/test_email_simple.py
@@ -6,6 +6,7 @@ Run this from the backend directory: python test_email_simple.py
 
 import os
 import django
+import pytest
 
 # Setup Django
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
@@ -18,96 +19,76 @@ from notifications.email_service import EmailService
 def test_email_service():
     """Test the EmailService directly"""
     print("=== Testing EmailService directly ===")
-    
-    # Replace with your email for testing
-    test_email = input("Enter your email for testing: ").strip()
-    
+
+    # Use TEST_EMAIL env var instead of interactive input
+    test_email = os.getenv("TEST_EMAIL")
     if not test_email:
-        print("No email provided, skipping direct email test")
-        return False
-    
+        pytest.skip("TEST_EMAIL not configured")
+
     print(f"Sending test email to: {test_email}")
-    
-    try:
-        success = EmailService.send_test_email(
-            recipient_email=test_email,
-            subject="Test Email from Medical App",
-            message="This is a test email to verify that the email configuration is working correctly."
-        )
-        
-        if success:
-            print("✅ Direct email test PASSED - Check your inbox!")
-            return True
-        else:
-            print("❌ Direct email test FAILED")
-            return False
-            
-    except Exception as e:
-        print(f"❌ Error in direct email test: {e}")
-        return False
+
+    success = EmailService.send_test_email(
+        recipient_email=test_email,
+        subject="Test Email from Medical App",
+        message="This is a test email to verify that the email configuration is working correctly.",
+    )
+
+    assert success
+    return True
 
 def test_notification_system():
     """Test the notification system with auto-email"""
     print("\n=== Testing Notification System with Auto-Email ===")
-    
-    try:
-        # Get or create a test user
-        user, created = User.objects.get_or_create(
-            username='test_email_user',
-            defaults={
-                'email': input("Enter your email for notification test: ").strip(),
-                'first_name': 'Test',
-                'last_name': 'User'
-            }
-        )
-        
-        if not user.email:
-            print("No email provided for user, skipping notification test")
-            return False
-        
-        print(f"Using test user: {user.username} ({user.email})")
-        
-        # Create an email notification (this should trigger auto-send)
-        notification = Notification.objects.create(
-            user=user,
-            type='email',
-            title='Test Notification Email',
-            message='This is a test notification created to verify that emails are sent automatically when notifications are created.'
-        )
-        
-        print(f"Created notification {notification.id}")
-        
-        # Refresh from database to get updated email_sent status
-        notification.refresh_from_db()
-        
-        if notification.email_sent:
-            print(f"✅ Notification system test PASSED - Email sent at {notification.email_sent_at}")
-            print("Check your inbox for the notification email!")
-            return True
-        else:
-            print("❌ Notification system test FAILED - Email not sent")
-            return False
-            
-    except Exception as e:
-        print(f"❌ Error in notification system test: {e}")
-        return False
+
+    # Get or create a test user
+    test_email = os.getenv("TEST_EMAIL")
+    if not test_email:
+        pytest.skip("TEST_EMAIL not configured")
+
+    user, created = User.objects.get_or_create(
+        username='test_email_user',
+        defaults={
+            'email': test_email,
+            'first_name': 'Test',
+            'last_name': 'User'
+        }
+    )
+
+    print(f"Using test user: {user.username} ({user.email})")
+
+    # Create an email notification (this should trigger auto-send)
+    notification = Notification.objects.create(
+        user=user,
+        type='email',
+        title='Test Notification Email',
+        message='This is a test notification created to verify that emails are sent automatically when notifications are created.'
+    )
+
+    print(f"Created notification {notification.id}")
+
+    # Refresh from database to get updated email_sent status
+    notification.refresh_from_db()
+
+    assert notification.email_sent
+    return True
+
 
 def main():
     print("🚀 Starting Email Integration Tests")
     print("=" * 50)
-    
+
     # Test 1: Direct email service
     test1_passed = test_email_service()
-    
+
     # Test 2: Notification system
     test2_passed = test_notification_system()
-    
+
     # Summary
     print("\n" + "=" * 50)
     print("📊 TEST SUMMARY:")
     print(f"Direct Email Test: {'✅ PASSED' if test1_passed else '❌ FAILED'}")
     print(f"Notification Email Test: {'✅ PASSED' if test2_passed else '❌ FAILED'}")
-    
+
     if all([test1_passed, test2_passed]):
         print("\n🎉 ALL TESTS PASSED! Email integration is working correctly!")
     else:

--- a/backend/test_race_async.py
+++ b/backend/test_race_async.py
@@ -36,7 +36,7 @@ class AsyncTester:
     
     async def make_appointment(self, session, token, patient_id, request_id):
         """Incercare programare"""
-        headers = {'Authorization': f'Token {token}'}
+        headers = {'Authorization': f'Bearer {token}'}
         appointment_data = {
             'doctor': DOCTOR_ID,
             'patient': patient_id,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import store from "@/store";
 
 const api = axios.create({
   baseURL: process.env.VUE_APP_API_URL || "/api/",
@@ -10,7 +11,14 @@ const api = axios.create({
   },
 });
 
-// No token injection needed; credentials (cookies) are sent automatically
+// Include access token-ul in toate requesturile
+api.interceptors.request.use((config) => {
+  const token = store.state.auth.token;
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
 
 // Interceptor pentru gestionarea raspunsurilor
 api.interceptors.response.use(

--- a/frontend/src/store/modules/auth.js
+++ b/frontend/src/store/modules/auth.js
@@ -87,6 +87,7 @@ export default {
           };
 
           commit("setUser", userData);
+          commit("setToken", response.data.token);
           return { success: true };
         }
       } catch (error) {
@@ -109,6 +110,7 @@ export default {
         };
 
         commit("setUser", userData);
+        commit("setToken", response.data.token);
         commit("setRequires2FA", { requires2FA: false, userId: null });
         return { success: true };
       } catch (error) {


### PR DESCRIPTION
- switch authentication to `Authorization: Bearer` headers and return a refresh token in an HttpOnly, SameSite=Strict cookie
- update frontend to attach bearer tokens on each request and store the token in Vuex state
- replace interactive email tests with environment-driven ones so `pytest` can run non-interactively