### PR TITLE
feat(auth): add refresh token flow and persistence

### DIFF
--- a/frontend/src/services/auth.service.js
+++ b/frontend/src/services/auth.service.js
@@ -40,4 +40,8 @@ export default {
   logout() {
     return api.post("auth/users/logout/");
   },
+
+  refresh() {
+    return api.post("auth/users/refresh/");
+  },
 };


### PR DESCRIPTION
## Summary
- persist auth token in local storage and refresh from HTTP-only cookie
- add backend refresh endpoint and tests for token rotation
- expose refresh method on frontend auth service

## Testing
- `SECRET_KEY=dummy python manage.py test`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68970caa7004832ebf54564bf42bafab