### PR TITLE
feat: add reusable loading spinner

### DIFF
--- a/frontend/src/components/admin/AdminAppointments.vue
+++ b/frontend/src/components/admin/AdminAppointments.vue
@@ -117,9 +117,7 @@
 
       <div class="card-body">
         <div v-if="loading" class="text-center p-4">
-          <div class="spinner-border" role="status">
-            <span class="visually-hidden">Loading...</span>
-          </div>
+          <LoadingSpinner />
         </div>
 
         <div

--- a/frontend/src/components/admin/AdminCreateAppointment.vue
+++ b/frontend/src/components/admin/AdminCreateAppointment.vue
@@ -59,7 +59,7 @@
         <div class="col-md-8 mb-3">
           <label class="form-label">Available Time Slots *</label>
           <div v-if="loadingSlots" class="text-center p-2">
-            <div class="spinner-border spinner-border-sm" role="status"></div>
+            <LoadingSpinner size="sm" />
             <span class="ms-2">Loading available slots...</span>
           </div>
           <div
@@ -128,11 +128,7 @@
             creating || !form.patient || !form.doctor || !form.schedule
           "
         >
-          <span
-            v-if="creating"
-            class="spinner-border spinner-border-sm me-2"
-            role="status"
-          ></span>
+          <LoadingSpinner v-if="creating" size="sm" class="me-2" />
           <i v-else class="bi bi-calendar-plus me-2"></i>
           Create Appointment
         </button>

--- a/frontend/src/components/admin/AdminCreateUser.vue
+++ b/frontend/src/components/admin/AdminCreateUser.vue
@@ -116,11 +116,7 @@
           Cancel
         </button>
         <button type="submit" class="btn btn-primary" :disabled="creating">
-          <span
-            v-if="creating"
-            class="spinner-border spinner-border-sm me-2"
-            role="status"
-          ></span>
+          <LoadingSpinner v-if="creating" size="sm" class="me-2" />
           <i v-else class="bi bi-person-plus me-2"></i>
           Create {{ userType === "doctor" ? "Doctor" : "Patient" }}
         </button>

--- a/frontend/src/components/admin/AdminEditUser.vue
+++ b/frontend/src/components/admin/AdminEditUser.vue
@@ -92,10 +92,7 @@
           Cancel
         </button>
         <button type="submit" class="btn btn-primary" :disabled="updating">
-          <span
-            v-if="updating"
-            class="spinner-border spinner-border-sm me-2"
-          ></span>
+          <LoadingSpinner v-if="updating" size="sm" class="me-2" />
           Update User
         </button>
       </div>

--- a/frontend/src/components/admin/AdminOverview.vue
+++ b/frontend/src/components/admin/AdminOverview.vue
@@ -69,9 +69,7 @@
           </div>
           <div class="card-body">
             <div v-if="loading" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div

--- a/frontend/src/components/admin/AdminScheduleManager.vue
+++ b/frontend/src/components/admin/AdminScheduleManager.vue
@@ -28,7 +28,7 @@
 
       <!-- Schedule list -->
       <div v-if="loading" class="text-center p-4">
-        <div class="spinner-border" role="status"></div>
+        <LoadingSpinner />
       </div>
 
       <div v-else class="table-responsive">
@@ -161,10 +161,11 @@
                   class="btn btn-primary"
                   :disabled="creatingSchedule"
                 >
-                  <span
+                  <LoadingSpinner
                     v-if="creatingSchedule"
-                    class="spinner-border spinner-border-sm me-2"
-                  ></span>
+                    size="sm"
+                    class="me-2"
+                  />
                   Create Schedule
                 </button>
               </div>

--- a/frontend/src/components/admin/AdminUsers.vue
+++ b/frontend/src/components/admin/AdminUsers.vue
@@ -87,9 +87,7 @@
         </div>
         <div class="card-body">
           <div v-if="loadingDoctors" class="text-center p-4">
-            <div class="spinner-border" role="status">
-              <span class="visually-hidden">Loading...</span>
-            </div>
+            <LoadingSpinner />
           </div>
 
           <div v-else-if="filteredDoctors.length === 0" class="text-center p-4">
@@ -174,9 +172,7 @@
         </div>
         <div class="card-body">
           <div v-if="loadingPatients" class="text-center p-4">
-            <div class="spinner-border" role="status">
-              <span class="visually-hidden">Loading...</span>
-            </div>
+            <LoadingSpinner />
           </div>
 
           <div

--- a/frontend/src/components/calendar/DoctorCalendar.vue
+++ b/frontend/src/components/calendar/DoctorCalendar.vue
@@ -3,9 +3,7 @@
     <h2 class="mb-4">Doctor's Schedule</h2>
 
     <div v-if="loading" class="text-center my-5">
-      <div class="spinner-border" role="status">
-        <span class="visually-hidden">Loading...</span>
-      </div>
+      <LoadingSpinner />
     </div>
 
     <div v-else>

--- a/frontend/src/components/calendar/PatientCalendar.vue
+++ b/frontend/src/components/calendar/PatientCalendar.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <div v-if="loading" class="text-center p-4">
-      <div class="spinner-border" role="status">
-        <span class="visually-hidden">Loading...</span>
-      </div>
+      <LoadingSpinner />
     </div>
 
     <div v-else>

--- a/frontend/src/components/common/LoadingSpinner.vue
+++ b/frontend/src/components/common/LoadingSpinner.vue
@@ -1,0 +1,22 @@
+<template>
+  <span :class="['spinner-border', sizeClass]" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </span>
+</template>
+
+<script>
+export default {
+  name: "LoadingSpinner",
+  props: {
+    size: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    sizeClass() {
+      return this.size ? `spinner-border-${this.size}` : "";
+    },
+  },
+};
+</script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
 import store from "./store";
+import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
 
 import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap-icons/font/bootstrap-icons.css";
@@ -12,6 +13,7 @@ window.bootstrap = bootstrap;
 
 // Initialize the app
 const app = createApp(App);
+app.component("LoadingSpinner", LoadingSpinner);
 
 // Check authentication status before mounting
 async function initializeApp() {

--- a/frontend/src/views/AppointmentDetails.vue
+++ b/frontend/src/views/AppointmentDetails.vue
@@ -16,9 +16,7 @@
           </div>
 
           <div v-if="loading" class="card-body text-center p-5">
-            <div class="spinner-border" role="status">
-              <span class="visually-hidden">Loading...</span>
-            </div>
+            <LoadingSpinner />
           </div>
 
           <template v-else-if="appointment">

--- a/frontend/src/views/Appointments.vue
+++ b/frontend/src/views/Appointments.vue
@@ -75,9 +75,7 @@
 
           <div class="card-body">
             <div v-if="loading" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div

--- a/frontend/src/views/BookAppointment.vue
+++ b/frontend/src/views/BookAppointment.vue
@@ -9,9 +9,7 @@
           <div class="card-header">Select a Doctor</div>
           <div class="card-body">
             <div v-if="loadingDoctors" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
             <div v-else>
               <div class="row">
@@ -173,11 +171,7 @@
                         class="btn btn-success"
                         :disabled="!confirmed || booking"
                       >
-                        <span
-                          v-if="booking"
-                          class="spinner-border spinner-border-sm me-2"
-                          role="status"
-                        ></span>
+                        <LoadingSpinner v-if="booking" size="sm" class="me-2" />
                         Book Appointment
                       </button>
                     </div>

--- a/frontend/src/views/DoctorDashboard.vue
+++ b/frontend/src/views/DoctorDashboard.vue
@@ -48,9 +48,7 @@
           <div class="card-header">Today's Appointments</div>
           <div class="card-body">
             <div v-if="loading" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div
@@ -147,9 +145,7 @@
           <div class="card-header">Recent Notifications</div>
           <div class="card-body">
             <div v-if="loadingNotifications" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div v-else-if="notifications.length === 0" class="text-center p-4">

--- a/frontend/src/views/DoctorSchedule.vue
+++ b/frontend/src/views/DoctorSchedule.vue
@@ -36,9 +36,7 @@
           <div class="card-header">My Schedule</div>
           <div class="card-body">
             <div v-if="loading" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div v-else>
@@ -140,11 +138,7 @@
                   class="btn btn-primary"
                   :disabled="saving"
                 >
-                  <span
-                    v-if="saving"
-                    class="spinner-border spinner-border-sm me-2"
-                    role="status"
-                  ></span>
+                  <LoadingSpinner v-if="saving" size="sm" class="me-2" />
                   Save
                 </button>
               </div>
@@ -292,11 +286,7 @@
                   class="btn btn-primary"
                   :disabled="bulkSaving"
                 >
-                  <span
-                    v-if="bulkSaving"
-                    class="spinner-border spinner-border-sm me-2"
-                    role="status"
-                  ></span>
+                  <LoadingSpinner v-if="bulkSaving" size="sm" class="me-2" />
                   Create Slots
                 </button>
               </div>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -34,11 +34,7 @@
               </div>
 
               <button type="submit" class="btn btn-primary" :disabled="loading">
-                <span
-                  v-if="loading"
-                  class="spinner-border spinner-border-sm"
-                  role="status"
-                ></span>
+                <LoadingSpinner v-if="loading" size="sm" />
                 Login
               </button>
             </form>
@@ -70,11 +66,7 @@
                 class="btn btn-primary"
                 :disabled="loading2FA"
               >
-                <span
-                  v-if="loading2FA"
-                  class="spinner-border spinner-border-sm"
-                  role="status"
-                ></span>
+                <LoadingSpinner v-if="loading2FA" size="sm" />
                 Verify
               </button>
             </form>

--- a/frontend/src/views/Notifications.vue
+++ b/frontend/src/views/Notifications.vue
@@ -22,9 +22,7 @@
 
           <div class="card-body">
             <div v-if="loading" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div v-else-if="notifications.length === 0" class="text-center p-4">

--- a/frontend/src/views/PatientDashboard.vue
+++ b/frontend/src/views/PatientDashboard.vue
@@ -53,9 +53,7 @@
           </div>
           <div class="card-body">
             <div v-if="loading" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div
@@ -158,9 +156,7 @@
           <div class="card-header">Recent Notifications</div>
           <div class="card-body">
             <div v-if="loadingNotifications" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -41,9 +41,7 @@
             <!-- Personal Information Tab -->
             <div v-if="activeTab === 'personal'">
               <div v-if="loadingProfile" class="text-center p-4">
-                <div class="spinner-border" role="status">
-                  <span class="visually-hidden">Loading...</span>
-                </div>
+                <LoadingSpinner />
               </div>
 
               <div v-else-if="personalInfoError" class="alert alert-danger">
@@ -141,11 +139,11 @@
                     class="btn btn-primary"
                     :disabled="savingPersonalInfo"
                   >
-                    <span
+                    <LoadingSpinner
                       v-if="savingPersonalInfo"
-                      class="spinner-border spinner-border-sm me-2"
-                      role="status"
-                    ></span>
+                      size="sm"
+                      class="me-2"
+                    />
                     Save Changes
                   </button>
                 </div>
@@ -282,11 +280,11 @@
                     class="btn btn-primary"
                     :disabled="savingPassword || !isPasswordFormValid"
                   >
-                    <span
+                    <LoadingSpinner
                       v-if="savingPassword"
-                      class="spinner-border spinner-border-sm me-2"
-                      role="status"
-                    ></span>
+                      size="sm"
+                      class="me-2"
+                    />
                     <i class="bi bi-key me-2" v-else></i>
                     Change Password
                   </button>
@@ -329,9 +327,7 @@
             <!-- Notification Preferences Tab -->
             <div v-if="activeTab === 'notifications'">
               <div v-if="loadingNotifications" class="text-center p-4">
-                <div class="spinner-border" role="status">
-                  <span class="visually-hidden">Loading...</span>
-                </div>
+                <LoadingSpinner />
               </div>
 
               <div v-else>
@@ -563,11 +559,11 @@
                       class="btn btn-primary"
                       :disabled="savingNotificationPrefs"
                     >
-                      <span
+                      <LoadingSpinner
                         v-if="savingNotificationPrefs"
-                        class="spinner-border spinner-border-sm me-2"
-                        role="status"
-                      ></span>
+                        size="sm"
+                        class="me-2"
+                      />
                       <i class="bi bi-bell me-2" v-else></i>
                       Save Preferences
                     </button>

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -115,11 +115,7 @@
                 class="btn btn-primary w-100"
                 :disabled="loading"
               >
-                <span
-                  v-if="loading"
-                  class="spinner-border spinner-border-sm me-2"
-                  role="status"
-                ></span>
+                <LoadingSpinner v-if="loading" size="sm" class="me-2" />
                 Register
               </button>
             </form>

--- a/frontend/src/views/TwoFactorAuth.vue
+++ b/frontend/src/views/TwoFactorAuth.vue
@@ -8,9 +8,7 @@
           <div class="card-header">2FA Settings</div>
           <div class="card-body">
             <div v-if="loading" class="text-center p-4">
-              <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
+              <LoadingSpinner />
             </div>
 
             <div v-else>
@@ -41,11 +39,7 @@
                   class="btn btn-primary"
                   :disabled="enabling"
                 >
-                  <span
-                    v-if="enabling"
-                    class="spinner-border spinner-border-sm me-2"
-                    role="status"
-                  ></span>
+                  <LoadingSpinner v-if="enabling" size="sm" class="me-2" />
                   Enable 2FA
                 </button>
               </div>
@@ -62,11 +56,7 @@
                     class="btn btn-danger"
                     :disabled="disabling"
                   >
-                    <span
-                      v-if="disabling"
-                      class="spinner-border spinner-border-sm me-2"
-                      role="status"
-                    ></span>
+                    <LoadingSpinner v-if="disabling" size="sm" class="me-2" />
                     Disable 2FA
                   </button>
 
@@ -75,11 +65,11 @@
                     class="btn btn-warning"
                     :disabled="regenerating"
                   >
-                    <span
+                    <LoadingSpinner
                       v-if="regenerating"
-                      class="spinner-border spinner-border-sm me-2"
-                      role="status"
-                    ></span>
+                      size="sm"
+                      class="me-2"
+                    />
                     Regenerate Backup Codes
                   </button>
                 </div>
@@ -136,7 +126,7 @@
                             class="qr-code img-fluid"
                           />
                           <div v-else class="qr-placeholder">
-                            <span class="spinner-border" role="status"></span>
+                            <LoadingSpinner />
                           </div>
                         </div>
 
@@ -195,11 +185,11 @@
                                 verifying || verificationCode.length !== 6
                               "
                             >
-                              <span
+                              <LoadingSpinner
                                 v-if="verifying"
-                                class="spinner-border spinner-border-sm me-2"
-                                role="status"
-                              ></span>
+                                size="sm"
+                                class="me-2"
+                              />
                               <i class="bi bi-check-circle me-2" v-else></i>
                               Complete Setup
                             </button>


### PR DESCRIPTION
## Summary
- add LoadingSpinner component with optional size prop
- register spinner globally and replace hard-coded spinners across views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979b19f9a4832eb0faf1b3015eed26