### PR TITLE
Centralize admin permissions and secure password reset

### DIFF
--- a/backend/authentication/permissions.py
+++ b/backend/authentication/permissions.py
@@ -1,0 +1,18 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsAdminRole(BasePermission):
+    """Allow access only to users with an admin profile role."""
+
+    def has_permission(self, request, view):
+        user = request.user
+        return bool(
+            user and user.is_authenticated and (
+                getattr(user, 'is_staff', False) or
+                getattr(user, 'is_superuser', False) or
+                (hasattr(user, 'profile') and user.profile.role == 'admin')
+            )
+        )
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)

--- a/backend/patients/views.py
+++ b/backend/patients/views.py
@@ -1,6 +1,7 @@
 from rest_framework import viewsets, permissions
 from .models import Patient
 from .serializers import PatientSerializer
+from authentication.permissions import IsAdminRole
 
 class PatientViewSet(viewsets.ModelViewSet):
     queryset = Patient.objects.all()
@@ -11,7 +12,7 @@ class PatientViewSet(viewsets.ModelViewSet):
         user = self.request.user
 
         # Admin can see all patients
-        if hasattr(user, 'profile') and user.profile.role == 'admin':
+        if IsAdminRole().has_permission(self.request, self):
             return Patient.objects.all().select_related('user')
 
         if user.is_staff or user.is_superuser:

--- a/frontend/src/components/admin/AdminCreateAppointment.vue
+++ b/frontend/src/components/admin/AdminCreateAppointment.vue
@@ -170,13 +170,31 @@ export default {
 
     const loadData = async () => {
       try {
-        const [doctorsResponse, patientsResponse] = await Promise.all([
-          AdminService.getAllDoctors(),
-          AdminService.getAllPatients(),
-        ]);
-
-        doctors.value = doctorsResponse.data;
-        patients.value = patientsResponse.data;
+        const response = await AdminService.getAllUsers();
+        const data = response.data.results || [];
+        doctors.value = data
+          .filter((u) => u.role === "doctor")
+          .map((u) => ({
+            id: u.id,
+            speciality: u.speciality,
+            user: {
+              id: u.id,
+              first_name: u.first_name,
+              last_name: u.last_name,
+              email: u.email,
+            },
+          }));
+        patients.value = data
+          .filter((u) => u.role === "patient")
+          .map((u) => ({
+            id: u.id,
+            user: {
+              id: u.id,
+              first_name: u.first_name,
+              last_name: u.last_name,
+              email: u.email,
+            },
+          }));
       } catch (err) {
         console.error("Failed to load doctors/patients", err);
         error.value = "Failed to load doctors and patients data";

--- a/frontend/src/components/admin/AdminScheduleManager.vue
+++ b/frontend/src/components/admin/AdminScheduleManager.vue
@@ -211,12 +211,24 @@ export default {
 
     const loadData = async () => {
       try {
-        const [doctorsResponse, schedulesResponse] = await Promise.all([
-          AdminService.getAllDoctors(),
+        const [usersResponse, schedulesResponse] = await Promise.all([
+          AdminService.getAllUsers(),
           AdminService.getAllSchedules(),
         ]);
 
-        doctors.value = doctorsResponse.data;
+        const data = usersResponse.data.results || [];
+        doctors.value = data
+          .filter((u) => u.role === "doctor")
+          .map((u) => ({
+            id: u.id,
+            speciality: u.speciality,
+            user: {
+              id: u.id,
+              first_name: u.first_name,
+              last_name: u.last_name,
+              email: u.email,
+            },
+          }));
         schedules.value = schedulesResponse.data;
       } catch (error) {
         console.error("Failed to load schedule data", error);

--- a/frontend/src/services/admin.service.js
+++ b/frontend/src/services/admin.service.js
@@ -7,14 +7,6 @@ export default {
   },
 
   // Users management
-  getAllDoctors() {
-    return api.get("doctors/doctors/");
-  },
-
-  getAllPatients() {
-    return api.get("patients/patients/");
-  },
-
   // Quick appointment booking pentru admin
   createAppointmentAsAdmin(appointmentData) {
     return api.post("appointments/", appointmentData);


### PR DESCRIPTION
## Summary
- add reusable `IsAdminRole` permission and DRF serializer for admin updates
- send reset passwords via email and paginate admin user list
- refactor admin UI to fetch users once and hide temporary passwords

## Testing
- `SECRET_KEY=dummy python manage.py test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898739a63b0832eac2626a739487267